### PR TITLE
Clear route on stop()

### DIFF
--- a/src/main/java/spark/Service.java
+++ b/src/main/java/spark/Service.java
@@ -409,11 +409,11 @@ public final class Service extends Routable {
     public synchronized void stop() {
         new Thread(() -> {
             if (server != null) {
-                routes.clear();
                 server.extinguish();
                 latch = new CountDownLatch(1);
             }
-
+            
+            routes.clear();
             staticFilesConfiguration.clear();
             initialized = false;
         }).start();


### PR DESCRIPTION
When testing with `Spark` , it appeare that when we provide our webserver, not using jetty server emmbedded, `Spark` keep routes from a scenarii to another.